### PR TITLE
Fix handle is invalid error on windows

### DIFF
--- a/GitCommitMsg.py
+++ b/GitCommitMsg.py
@@ -20,8 +20,12 @@ class GitCommitMsgThread(threading.Thread):
 
   def run(self):
     print('GitCommitMsg - Command: %s' % self.command)
-    pr = subprocess.Popen(self.command, cwd = self.dir_name, \
-      shell = True, stdout = subprocess.PIPE, stderr = subprocess.PIPE)
+    pr = subprocess.Popen(self.command,
+      cwd = self.dir_name,
+      shell = True,
+      stdout = subprocess.PIPE,
+      stderr = subprocess.PIPE,
+      stdin = subprocess.PIPE)
     (out, error) = pr.communicate()
     self.result = out
 


### PR DESCRIPTION
The package doesn't currently seem to work on windows since it throws this error:

```
GitCommitMsg - Command: echo off && for /f "tokens=1" %a in ( '"git blame "C:\proj\test.txt" -L 23,23 --root -s -l"') do git show --name-status "%a"
Exception in thread Thread-119:
Traceback (most recent call last):
  File ".\threading.py", line 532, in __bootstrap_inner
  File ".\GitCommitMsg.py", line 24, in run
  File ".\subprocess.py", line 626, in __init__
  File ".\subprocess.py", line 734, in _get_handles
  File ".\subprocess.py", line 773, in _make_inheritable
WindowsError: [Error 6] The handle is invalid
```

this seems to be due to an issue with python on windows which is documented here: http://bugs.python.org/issue3905
It's basically caused if you don't tell subprocess to PIPE all of the
handles so the fix is to specify stdin = subprocess.PIPE
