### PR TITLE
Fix empty message in newer Sublime Text 4 versions 

### DIFF
--- a/GitCommitMsg.py
+++ b/GitCommitMsg.py
@@ -73,7 +73,7 @@ class GitCommitMsgResultCommand(sublime_plugin.TextCommand):
   """
   def run(self, edit, file_name, start_line, end_line, result):
     new_file = self.view.window().new_file()
-    new_file.insert(edit, 0, result)
+    new_file.run_command("append", {"characters": result})
     new_file.set_scratch(True)
     new_file.set_read_only(True)
     syntax = "Packages/GitCommitMsg/GitCommitMsg.tmLanguage"


### PR DESCRIPTION
The `new_file.insert` method was misusing the `edit` parameter. Instead we can invoke a command to append text in the newly created window.

**Context:**

The edit parameter is not for new_file but for self.view.

Build 4158
https://www.sublimetext.com/dev
-  API: Fixed crash when an edit token is passed to the wrong view


API Docs:
https://www.sublimetext.com/docs/api_reference.html#sublime.Edit

> Edit objects are passed to TextCommands, and can not be created by the user. Using an invalid Edit object, or an Edit object from a different View, will cause the functions that require them to fail.


My report on Sublime Text bug tracker:
https://github.com/sublimehq/sublime_text/issues/6177


Closes issue #25 